### PR TITLE
Fixes #5, use the correct name for : - colon not semicolon.

### DIFF
--- a/jsonlint.js
+++ b/jsonlint.js
@@ -255,7 +255,7 @@ JSONLint.prototype = {
 				return self.value();
 			}
 			else {
-				throw "Unknown Character '" + self.c + "', expecting a semicolon.";
+				throw "Unknown Character '" + self.c + "', expecting a colon.";
 			}
 		}
 	},


### PR DESCRIPTION
The : character was described as a semicolon in the error message. However, the correct name for it is a colon.